### PR TITLE
Some buttons (Checkout Paypal) are still displayed

### DIFF
--- a/src/components/spinner/spinner.component.scss
+++ b/src/components/spinner/spinner.component.scss
@@ -47,7 +47,7 @@
     justify-content: center;
     align-items: center;
     flex-direction: column;
-    z-index: 5;
+    z-index: 100;
 
     .loader.default {
         width: 100px;

--- a/src/components/spinner/spinner.component.scss
+++ b/src/components/spinner/spinner.component.scss
@@ -47,7 +47,7 @@
     justify-content: center;
     align-items: center;
     flex-direction: column;
-    z-index: 100;
+    z-index: 200;
 
     .loader.default {
         width: 100px;


### PR DESCRIPTION
Increase the z-index in order to not display buttons with a high z-index (like Checkout Paypal buttons)
![image](https://user-images.githubusercontent.com/17111789/121679262-6e677800-cab8-11eb-9db5-95ffae0638df.png)
